### PR TITLE
Removed obsolete parameter to force default gravatar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "fate/gravatar-php",
+    "name": "mheap/gravatar-php",
     "description": "PHP 5.3 Library for Gravatar (gravatar.com)",
     "keywords": ["gravatar"],
-    "homepage": "https://github.com/fate/Gravatar-php",
+    "homepage": "https://github.com/sveneisenschmidt/Gravatar-php",
     "type": "library",
     "license": "MIT",
     "version": "1.0.0",

--- a/src/Gravatar/Service.php
+++ b/src/Gravatar/Service.php
@@ -85,8 +85,7 @@ class Service
         'size'   => 75,
         'rating' => self::RATING_G,
         'secure' => false,
-        'default'   => null,
-        'force_default' => false
+        'default'   => null
     );
     
     /**
@@ -124,8 +123,7 @@ class Service
         $params  = array(
             's' => $options['size'],
             'd' => $options['default'],
-            'r' => $options['rating'],
-            'f' => ($options['force_default'] == true) ? 'y' : null
+            'r' => $options['rating']
         );
         
         $url  = vsprintf(self::URL, array($options['secure'] ? 'https' : 'http', $hash));


### PR DESCRIPTION
The full URL to obtain a Gravatar no longer supports the 'f' argument and if specified results in a 404 from the Gravatar website.

This removes these options from the service so that the Gravatar URL is built correctly.
